### PR TITLE
Fix for 12hour clocks

### DIFF
--- a/src/gcal-time-selector.c
+++ b/src/gcal-time-selector.c
@@ -142,7 +142,7 @@ gcal_time_selector_set_time_format (GcalTimeSelector *selector,
   if (format_24h)
     gtk_adjustment_set_upper (gtk_spin_button_get_adjustment (GTK_SPIN_BUTTON (priv->hour_spin)), 23.0);
   else
-    gtk_adjustment_set_upper (gtk_spin_button_get_adjustment (GTK_SPIN_BUTTON (priv->hour_spin)), 11.0);
+    gtk_adjustment_set_upper (gtk_spin_button_get_adjustment (GTK_SPIN_BUTTON (priv->hour_spin)), 12.0);
 }
 
 static void
@@ -276,7 +276,7 @@ gcal_time_selector_get_time (GcalTimeSelector *selector,
       gint am_pm;
 
       am_pm = gtk_combo_box_get_active (GTK_COMBO_BOX (priv->period_combo));
-      *hours = (gint) gtk_adjustment_get_value (hour_adj) + 12 * am_pm;
+      *hours = (gint) gtk_adjustment_get_value (hour_adj) % 12 + 12 * am_pm;
     }
 
   /* minute field isn't dependant on 12h/24h format */

--- a/src/gcal-time-selector.c
+++ b/src/gcal-time-selector.c
@@ -238,6 +238,9 @@ gcal_time_selector_set_time (GcalTimeSelector *selector,
 
       period = hours < 12? AM : PM;
       hours = hours % 12;
+      if(hours == 0){
+        hours = 12;
+      }
 
       gtk_combo_box_set_active (GTK_COMBO_BOX (priv->period_combo), period);
       gtk_adjustment_set_value (hour_adj, hours);


### PR DESCRIPTION
The 12hour clock in gnome-calendar displays the time "12:30pm" as "00:30pm" which is not the standard(at least that is not the standard here in north america). This patch fixes this in the edit box for both the entering and display of values.
