### PR TITLE
gcal-window: Dynamic Today's button

### DIFF
--- a/src/gcal-window.c
+++ b/src/gcal-window.c
@@ -383,7 +383,14 @@ update_active_date (GcalWindow   *window,
       g_clear_pointer (&date_start, g_date_time_unref);
       g_clear_pointer (&date_end, g_date_time_unref);
     }
-
+  if((window->current_date->year== window->active_date->year) && (window->current_date->month== window->active_date->month) && (window->current_date->day== window->active_date->day))
+    {
+      gtk_widget_set_sensitive(window->today_button, FALSE);
+    }
+  else
+    {
+      gtk_widget_set_sensitive(window->today_button, TRUE);
+    }
   g_free (previous_date);
 }
 


### PR DESCRIPTION
The Today button was always sensitive even if the active date was the
current date.

To fix this, I modified the method update_active_date(), using a
conditional to compare the active date and the current date,
if the date is the same then the button is insensitive,
other else the button is sensitive.

Closes: https://bugzilla.gnome.org/show_bug.cgi?id=747963