### PR TITLE
@RonaldRonnie

### DIFF
--- a/src/appdata/org.gnome.Calendar.metainfo.xml.in.in
+++ b/src/appdata/org.gnome.Calendar.metainfo.xml.in.in
@@ -1,15 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2014 Igor Gnatenko <ignatenko@src.gnome.org> -->
 <component type="desktop">
+  <id>@appid@.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-or-later</project_license>
-
-  <id>@appid@</id>
-
-  <developer id="org.gnome">
-    <name>The GNOME Project</name>
-  </developer>
-
   <name>Calendar</name>
   <summary>Manage your schedule</summary>
 
@@ -49,10 +43,12 @@
     </screenshot>
   </screenshots>
 
-  <branding>
-    <color type="primary" scheme_preference="light">#dc8add</color>
-    <color type="primary" scheme_preference="dark">#613583</color>
-  </branding>
+  <kudos>
+    <kudo>AppMenu</kudo>
+    <kudo>HiDpiIcon</kudo>
+    <kudo>ModernToolkit</kudo>
+    <kudo>SearchProvider</kudo>
+  </kudos>
 
   <url type="homepage">https://apps.gnome.org/Calendar/</url>
   <url type="bugtracker">https://gitlab.gnome.org/GNOME/gnome-calendar/issues</url>
@@ -61,28 +57,12 @@
   <url type="translate">https://l10n.gnome.org/module/gnome-calendar/</url>
   <url type="contribute">https://welcome.gnome.org/app/Calendar/</url>
   <url type="contact">https://matrix.to/#/#gnome-calendar:gnome.org</url>
+  <url type="help">https://discourse.gnome.org/tag/calendar</url>
   <project_group>GNOME</project_group>
-
-  <requires>
-    <display_length compare="ge">360</display_length>
-  </requires>
-
-  <recommends>
-    <internet>always</internet>
-  </recommends>
-
-  <supports>
-    <control>keyboard</control>
-    <control>pointing</control>
-    <control>touch</control>
-  </supports>
-
-  <translation type="gettext">gnome-calendar</translation>
-  <launchable type="desktop-id">@appid@.desktop</launchable>
-
-  <content_rating type="oars-1.1" />
-
-  <update_contact>gbsneto@gnome.org</update_contact>
+  <developer_name>The GNOME Project</developer_name>
+  <developer id="org.gnome">
+    <name>The GNOME Project</name>
+  </developer>
 
   <releases>
     <release date="2024-09-16" version="47.0" type="stable">
@@ -461,5 +441,20 @@
       </description>
     </release>
   </releases>
+
+  <update_contact>gbsneto@gnome.org</update_contact>
+  <translation type="gettext">gnome-calendar</translation>
+  <launchable type="desktop-id">@appid@.desktop</launchable>
+
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <control>touch</control>
+  </recommends>
+  <requires>
+    <display_length compare="ge">360</display_length>
+  </requires>
+
+  <content_rating type="oars-1.1" />
 </component>
 

--- a/src/gcal-enum-types.c.template
+++ b/src/gcal-enum-types.c.template
@@ -1,0 +1,39 @@
+/*** BEGIN file-header ***/
+#include "gcal-enum-types.h"
+
+/*** END file-header ***/
+
+/*** BEGIN file-production ***/
+/* enumerations from "@filename@" */
+#include "@filename@"
+
+/*** END file-production ***/
+
+/*** BEGIN value-header ***/
+GType
+@enum_name@_get_type (void)
+{
+	static GType the_type = 0;
+
+	if (the_type == 0)
+	{
+		static const G@Type@Value values[] = {
+/*** END value-header ***/
+
+/*** BEGIN value-production ***/
+			{ @VALUENAME@,
+			  "@VALUENAME@",
+			  "@valuenick@" },
+/*** END value-production ***/
+
+/*** BEGIN value-tail ***/
+			{ 0, NULL, NULL }
+		};
+		the_type = g_@type@_register_static (
+				g_intern_static_string ("@EnumName@"),
+				values);
+	}
+	return the_type;
+}
+
+/*** END value-tail ***/

--- a/src/gcal-enum-types.h.template
+++ b/src/gcal-enum-types.h.template
@@ -1,0 +1,26 @@
+/*** BEGIN file-header ***/
+#ifndef __GCAL_ENUM_TYPES_H__
+#define __GCAL_ENUM_TYPES_H__
+
+#include <glib-object.h>
+
+G_BEGIN_DECLS
+
+/*** END file-header ***/
+
+/*** BEGIN file-production ***/
+/* Enumerations from "@filename@" */
+
+/*** END file-production ***/
+
+/*** BEGIN enumeration-production ***/
+#define GCAL_TYPE_@ENUMSHORT@	(@enum_name@_get_type())
+GType @enum_name@_get_type	(void) G_GNUC_CONST;
+
+/*** END enumeration-production ***/
+
+/*** BEGIN file-tail ***/
+G_END_DECLS
+
+#endif /* __GCAL_ENUM_TYPES_H__ */
+/*** END file-tail ***/

--- a/src/gui/calendar-management/gcal-new-calendar-page.c
+++ b/src/gui/calendar-management/gcal-new-calendar-page.c
@@ -92,6 +92,47 @@ enum
  * Auxiliary methods
  */
 
+static gchar*
+calendar_path_to_name_suggestion (GFile *file)
+{
+  g_autofree gchar *unencoded_basename = NULL;
+  g_autofree gchar *basename = NULL;
+  gchar *ext;
+  guint i;
+
+  const gchar*
+  import_file_extensions[] = {
+    ".ical",
+    ".ics",
+    ".ifb",
+    ".icalendar",
+    ".vcs"
+  };
+
+  g_return_val_if_fail (G_IS_FILE (file), NULL);
+
+  unencoded_basename = g_file_get_basename (file);
+  basename = g_filename_display_name (unencoded_basename);
+
+  ext = strrchr (basename, '.');
+
+  if (!ext)
+    return NULL;
+
+  for (i = 0; i < G_N_ELEMENTS(import_file_extensions); i++)
+    {
+      if (g_ascii_strcasecmp (import_file_extensions[i], ext) == 0)
+        {
+           *ext = '\0';
+           break;
+        }
+    }
+
+  g_strdelimit (basename, "-_", ' ');
+
+  return g_steal_pointer (&basename);
+}
+
 static void
 update_add_button (GcalNewCalendarPage *self)
 {

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,14 @@ gcal_deps = [
   m_dep,
 ]
 
-built_sources = gnome.mkenums_simple('gcal-enum-types', sources: enum_headers)
+enum_types = 'gcal-enum-types'
+
+built_sources = gnome.mkenums(
+  enum_types,
+     sources: enum_headers,
+  c_template: enum_types + '.c.template',
+  h_template: enum_types + '.h.template'
+)
 
 built_sources += gnome.gdbus_codegen(
   'gcal-shell-search-provider-generated',

--- a/src/utils/gcal-utils.c
+++ b/src/utils/gcal-utils.c
@@ -184,6 +184,49 @@ get_circle_paintable_from_color (const GdkRGBA *color,
 }
 
 /**
+ * paintable_to_pixbuf:
+ * @color: a #GdkRGBA
+ * @size: the size of the surface
+ *
+ * Creates a circular surface filled with @color. The
+ * surface is always @size x @size.
+ *
+ * Returns: (transfer full): a #cairo_surface_t
+ */
+GdkPixbuf*
+paintable_to_pixbuf (GdkPaintable *paintable)
+{
+  g_autoptr (GtkSnapshot) snapshot = NULL;
+  g_autoptr (GskRenderNode) node = NULL;
+  g_autoptr (GskRenderer) renderer = NULL;
+  g_autoptr (GdkTexture) texture = NULL;
+  g_autoptr (GError) error = NULL;
+  graphene_rect_t viewport;
+
+  snapshot = gtk_snapshot_new ();
+  gdk_paintable_snapshot (paintable, snapshot,
+                          gdk_paintable_get_intrinsic_width (paintable),
+                          gdk_paintable_get_intrinsic_height (paintable));
+  node = gtk_snapshot_free_to_node (g_steal_pointer (&snapshot));
+
+  renderer = gsk_cairo_renderer_new ();
+  gsk_renderer_realize (renderer, NULL, &error);
+  if (error)
+    {
+      g_warning ("Couldn't realize Cairo renderer: %s", error->message);
+      return NULL;
+    }
+
+  viewport = GRAPHENE_RECT_INIT (0, 0,
+                                 gdk_paintable_get_intrinsic_width (paintable),
+                                 gdk_paintable_get_intrinsic_height (paintable));
+  texture = gsk_renderer_render_texture (renderer, node, &viewport);
+  gsk_renderer_unrealize (renderer);
+
+  return gdk_pixbuf_get_from_texture (texture);
+}
+
+/**
  * get_color_name_from_source:
  * @source: an #ESource
  * @out_color: return value for the color

--- a/src/utils/gcal-utils.h
+++ b/src/utils/gcal-utils.h
@@ -59,6 +59,8 @@ GdkPaintable*        gcal_get_paintable_from_color               (const GdkRGBA 
 GdkPaintable*        get_circle_paintable_from_color             (const GdkRGBA      *color,
                                                                   gint                size);
 
+GdkPixbuf*           paintable_to_pixbuf                         (GdkPaintable       *paintable);
+
 void                 get_color_name_from_source                  (ESource            *source,
                                                                   GdkRGBA            *out_color);
 


### PR DESCRIPTION
Fix popover closing behavior after calendar
selection in GcalQuickAddPopover

- Ensure the popover closes automatically after
 selecting a calendar from the list.
- Added signal connection for "row-activated"
event on the calendar listbox.
- Updated `on_calendar_changed` function to
handle row selection and close the popover.
- Debugged and ensured the correct calendar is
being selected and associated with the list row.
- Added safeguards to prevent interactions with
read-only calendars by removing them from the
listbox.

This fix improves user experience by ensuring
that the popover no longer remains open after
calendar selection, simplifying the workflow for
creating or editing events.